### PR TITLE
Add include repos option

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,8 @@ is the road to madness...
 To run this script on CentOS you need:
  - pulp-admin-client
  - pulp-rpm-admin-extensions
- - perl-Switch
  - perl-XML-Simple
  - perl-Text-Unidecode 
- - perl-Frontier-RPC
 
 This script was modified from Steve Meier's script for spacewalk 
 which can be found at http://cefs.steve-meier.de/

--- a/errata_import.pl
+++ b/errata_import.pl
@@ -30,10 +30,8 @@
 # Load modules
 use strict;
 use warnings;
-use Switch;
 use Data::Dumper;
 use Getopt::Long;
-import Frontier::Client;
 import Text::Unidecode;
 import XML::Simple;
 
@@ -204,12 +202,10 @@ foreach $advisory (sort(keys(%{$xml}))) {
       #################################
 
       ####### Select correct type #####
-      switch ($xml->{$advisory}->{type}) {
-		case "Security Advisory" {  $type = "security"; }
-		case "Bug Fix Advisory"	{ $type = "bugfix"; }
-		case "Product Enhancement Advisory" { $type = "enhancement"; }
+		if($xml->{$advisory}->{type} eq "Security Advisory") {  $type = "security"; }
+		elsif($xml->{$advisory}->{type} eq "Bug Fix Advisory")	{ $type = "bugfix"; }
+		elsif($xml->{$advisory}->{type} eq "Product Enhancement Advisory") { $type = "enhancement"; }
 		else { $type = $xml->{$advisory}->{type}; }
-      }
       #################################
 
       ####### Upload the errata #######
@@ -270,9 +266,6 @@ sub usage() {
 }
 
 sub eval_modules() {
-  eval { require Frontier::Client; };
-  if ($@) { die "ERROR: You are missing XML::Simple\n       CentOS: yum install perl-Frontier-RPC\n"; };
-
   eval { require Text::Unidecode; };
   if ($@) { die "ERROR: You are missing Text::Unidecode\n       CentOS: yum install perl-Text-Unidecode\n"; };
 


### PR DESCRIPTION
If you have RHEL and CentOS repos in your pulp when building the package to repo hash then you can end up with the packages all mapped to your RHEL repos and not your CentOS repos resulting in all the CentOS errata being pushed into the RHEL repo.

I've added a command line option to allow you to specify a list of repos to consider when building the package to repo hash allowing a user to work around that issue. 

I've also removed the dependency on unneeded packages (perl-Frontier-RPC doesn't appear to be used at all in this script and perl-Switch was only needed for one very small switch statement).
