### PR TITLE
Cleanup ref and pack files after uploading

### DIFF
--- a/errata_import.pl
+++ b/errata_import.pl
@@ -278,6 +278,8 @@ foreach $advisory (sort(keys(%{$xml}))) {
       &info("$result\n");
       #################################
 
+      unlink($reffile, $packfile);
+
     } else {
       # There is no related package so there is no errata created
       &notice("Skipping errata $advid ($xml->{$advisory}->{synopsis}) -- No packages found\n");


### PR DESCRIPTION
Running errata_import.pl leaves around a bunch of ref and pack files in /tmp. This patch removes these temp files when they're no longer required.