### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ which can be found at http://cefs.steve-meier.de/
   3. Run the script  
      wget -N http://cefs.steve-meier.de/errata.latest.xml
      ./errata_import.pl --errata=errata.latest.xml [--user=admin] [--password=pass]  
-  4. Go to "Administer" > "Settings" > "Katello" and set "force_post_sync_action" to true. (Katello 3.0 and up)
-  5. Sync repositories so that errata is published. (The errata will not show up on the Katello/Foreman interface until this step is completed. )
+  4. Sync repositories so that errata is published. (The errata will not show up on the Katello/Foreman interface until this step is completed. ) i.e.: hammer repository synchronize --skip-metadata-check "true" --name "CentOS 7 Updates" --product "CentOS 7 Updates"
 
 # Authentication
 


### PR DESCRIPTION
The older "force_post_sync_actions" setting was deprecated, then removed. Current versions use the ephemeral setting "--skip-metadata-check true/false", which must be invoked every time, as shown. Thanks for your work on this utility.